### PR TITLE
chore: Bump version to 5.7.10

### DIFF
--- a/.tx/deepin.conf
+++ b/.tx/deepin.conf
@@ -1,0 +1,2 @@
+[transifex]
+branch = m20

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+deepin-boot-maker (5.7.10) unstable; urgency=medium
+
+  * chore: adapt license and copyright (#45)(Task: 187933)
+  * docs: linux dependency update (#32)
+    Thanks to Alvaro Samudio
+  * fix: remove macOS and windows support (#46)
+    Thanks to guonafu
+  * feat: Adapt dbus security standard.(Task: 310479)
+
+ -- renbin <renbin@uniontech.com>  Fri, 22 Dec 2023 11:14:14 +0800
+
 deepin-boot-maker (5.6.12-1) unstable; urgency=low
 
   * fix lintian warnings


### PR DESCRIPTION
Add tx/deepin.conf config.
Bump version to 5.7.10
PR:
* https://github.com/linuxdeepin/deepin-boot-maker/pull/45
* https://github.com/linuxdeepin/deepin-boot-maker/pull/32
* https://github.com/linuxdeepin/deepin-boot-maker/pull/46
* https://github.com/linuxdeepin/deepin-boot-maker/pull/58

Log: Bump version to 5.7.10