### PR TITLE
chore: Bump version to 6.0.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-boot-maker (6.0.2) unstable; urgency=medium
+
+  * i18n: Updates for project Deepin Boot Maker (#70)
+  * chore: update translations.
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 10:40:47 +0800
+
 deepin-boot-maker (6.0.1) unstable; urgency=medium
 
   * fix: Fixed the issue that the boot disk failed to be created(Bug: 303439)


### PR DESCRIPTION
Bump version to 6.0.2

Log: Bump version to 6.0.2

## Summary by Sourcery

Chores:
- Bump project version to 6.0.2 in the Debian package changelog