### PR TITLE
chore: Disable deepin-boot-maker.service

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-boot-maker (6.0.3) unstable; urgency=medium
+
+  * update debian/rules to disable service
+
+ -- wangrong <wangrong@uniontech.com>  Mon, 19 May 2025 14:50:50 +0800
+
 deepin-boot-maker (6.0.2) unstable; urgency=medium
 
   * i18n: Updates for project Deepin Boot Maker (#70)

--- a/debian/rules
+++ b/debian/rules
@@ -26,4 +26,7 @@ override_dh_shlibdeps:
 override_dh_auto_test:
 	# Skip running tests
 	echo "Skipping tests"
-	
+
+override_dh_installsystemd:
+	# Disable deepin-boot-maker.service auto-start
+


### PR DESCRIPTION
As title.

Log: Disable automatic startup of service
Task: https://pms.uniontech.com/task-view-376639.html

## Summary by Sourcery

Disable automatic startup of deepin-boot-maker.service in Debian packaging

Chores:
- Add changelog entry noting disablement of deepin-boot-maker.service
- Update debian/rules to disable deepin-boot-maker.service at install time