### PR TITLE
 chore: Comment out tests subdirectory in src.pro          - Commented out the SUBDIRS entry for tests in src.pro to exclude it from the build process.     - Updated security compilation flags in tests.pro to use -fPIE instead of -fPIC for better compatibility.          Log: Adjust project structure and enhance security compilation settings.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-boot-maker (6.0.6) unstable; urgency=medium
+
+  * chore: Comment out tests subdirectory in src.pro
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 19 Jun 2025 19:46:23 +0800
+
 deepin-boot-maker (6.0.5) unstable; urgency=medium
 
   * chore: Update compiler flags for security enhancements

--- a/src/src.pro
+++ b/src/src.pro
@@ -10,7 +10,11 @@ linux {
 
 }
 SUBDIRS += app
-SUBDIRS += tests
+
+
+#SUBDIRS += tests
+
+
 mac* {
     TRANSLATIONS_NAME = deepin-boot-maker
     TRANSLATIONS += $$PWD/translations/$${TRANSLATIONS_NAME}.ts \

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -9,8 +9,8 @@ CONFIG(debug, debug|release) {
 
 #添加安全编译参数
 QMAKE_LFLAGS += -z noexecstack -pie -z relro -z now
-QMAKE_CFLAGS += -fstack-protector-all -fPIC
-QMAKE_CXXFLAGS += -fstack-protector-all -fno-access-control -fPIC
+QMAKE_CFLAGS += -fstack-protector-all -fPIE
+QMAKE_CXXFLAGS += -fstack-protector-all -fno-access-control -fPIE
 
 
 QT += core gui widgets testlib


### PR DESCRIPTION
chore: Comment out tests subdirectory in src.pro
   
   - Commented out the SUBDIRS entry for tests in src.pro to exclude it from the build process.
   - Updated security compilation flags in tests.pro to use -fPIE instead of -fPIC for better compatibility.
   
   Log: Adjust project structure and enhance security compilation settings.

## Summary by Sourcery

Exclude the tests subdirectory from the main build and tighten security compilation settings for test targets

Enhancements:
- Replace -fPIC with -fPIE in tests.pro CFLAGS and CXXFLAGS to enable position-independent executables

Build:
- Comment out the SUBDIRS entry for tests in src.pro to prevent tests from being built