### PR TITLE
chore: update version to 6.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-boot-maker (6.0.8) unstable; urgency=medium
+
+  * chore: New version 6.0.8.
+  * fix: Update dman's title.
+
+ -- re2zero <yangwu@uniontech.com>  Tue, 24 Jun 2025 18:43:13 +0800
+
 deepin-boot-maker (6.0.7) unstable; urgency=medium
 
   * chore: New version 6.0.7.

--- a/src/help/deepin-boot-maker/boot-maker/en_US/boot-maker.md
+++ b/src/help/deepin-boot-maker/boot-maker/en_US/boot-maker.md
@@ -1,4 +1,4 @@
-# Boot Disk Creation Tool | deepin-boot-maker
+# Boot Disk Creation Tool|deepin-boot-maker|
 
 ## Overview
 

--- a/src/help/deepin-boot-maker/boot-maker/zh_HK/boot-maker.md
+++ b/src/help/deepin-boot-maker/boot-maker/zh_HK/boot-maker.md
@@ -1,4 +1,4 @@
-# 啟動碟製作工具 | deepin-boot-maker
+# 啟動碟製作工具|deepin-boot-maker|
 
 ## 概述
 

--- a/src/help/deepin-boot-maker/boot-maker/zh_TW/boot-maker.md
+++ b/src/help/deepin-boot-maker/boot-maker/zh_TW/boot-maker.md
@@ -1,4 +1,4 @@
-# 開機碟製作工具 | deepin-boot-maker
+# 開機碟製作工具|deepin-boot-maker|
 
 ## 概述
 


### PR DESCRIPTION
fix dman's title: adjust header formatting in documentation, update version to 6.0.8

Log: update version to 6.0.8

## Summary by Sourcery

Update version to 6.0.8 and adjust header formatting in deepin-boot-maker documentation

Documentation:
- Standardize header formatting in English, Hong Kong Chinese, and Taiwan Chinese markdown files for deepin-boot-maker

Chores:
- Bump package version to 6.0.8 in the Debian changelog