### PR TITLE
refactor(service): replace custom caller check with polkit authorization

### DIFF
--- a/src/service/bootmakerservice.cpp
+++ b/src/service/bootmakerservice.cpp
@@ -58,51 +58,6 @@ bool checkAuthorization(qint64 pid, const QString &action)
 #endif
 }
 
-#if 0 // Not use now
-int getProcIdByExeName(std::string execName)
-{
-    int pid = -1;
-
-    // Open the /proc directory
-    DIR *dp = opendir("/proc");
-    if (dp != NULL) {
-        // Enumerate all entries in directory until process found
-        struct dirent *dirp;
-        while (pid < 0 && (dirp = readdir(dp))) {
-            // Skip non-numeric entries
-            int id = atoi(dirp->d_name);
-            if (id > 0) {
-                // Read contents of virtual /proc/{pid}/cmdline file
-                auto exeSymlinkPath = std::string("/proc/") + dirp->d_name + "/exe";
-                char *actualpath = realpath(exeSymlinkPath.c_str(), NULL);
-                if (actualpath) {
-                    // Compare against requested process name
-                    if (execName == actualpath) {
-                        pid = id;
-                    }
-                }
-            }
-        }
-    }
-
-    closedir(dp);
-
-    return pid;
-}
-#endif
-
-static QString getProcIdExe(qint64 id)
-{
-    QString execName;
-    if (id > 0) {
-        // Read contents of virtual /proc/{pid}/cmdline file
-        QString exeSymlinkPath = QString("/proc/%1/exe").arg(id);
-        char *actualpath = realpath(exeSymlinkPath.toStdString().c_str(), NULL);
-        execName = QString(actualpath);
-    }
-    return execName;
-}
-
 BootMakerService::BootMakerService(QObject *parent) :
     QObject(parent), d_ptr(new BootMakerServicePrivate(this))
 {
@@ -152,7 +107,7 @@ void BootMakerService::Reboot()
 void BootMakerService::Start()
 {
     Q_D(BootMakerService);
-    if (!d->checkCaller()) {
+    if (!d->disableCheck && !checkAuthorization(d->dbusCallerPid(), s_PolkitActionCreate)) {
         return;
     }
 
@@ -162,7 +117,7 @@ void BootMakerService::Start()
 void BootMakerService::Stop()
 {
     Q_D(BootMakerService);
-    if (!d->checkCaller()) {
+    if (!d->disableCheck && !checkAuthorization(d->dbusCallerPid(), s_PolkitActionCreate)) {
         return;
     }
 
@@ -178,7 +133,7 @@ QString BootMakerService::DeviceList()
 {
     qDebug() << "BootMakerService DeviceList";
     Q_D(BootMakerService);
-    if (!d->checkCaller()) {
+    if (!d->disableCheck && !checkAuthorization(d->dbusCallerPid(), s_PolkitActionCreate)) {
         return "";
     }
     return deviceListToJson(d->bm->deviceList());
@@ -187,10 +142,6 @@ QString BootMakerService::DeviceList()
 bool BootMakerService::Install(const QString &image, const QString &device, const QString &partition,  bool formatDevice)
 {
     Q_D(BootMakerService);
-    if (!d->checkCaller()) {
-        return false;
-    }
-
     if (!d->disableCheck && !checkAuthorization(d->dbusCallerPid(), s_PolkitActionCreate)) {
         return false;
     }
@@ -204,38 +155,12 @@ bool BootMakerService::CheckFile(const QString &filepath)
 {
     Q_D(BootMakerService);
 
-    // if (!d->checkCaller()) {
+    // if (!d->disableCheck && !checkAuthorization(d->dbusCallerPid(), s_PolkitActionCreate)) {
     //     return false;
     // }
     return d->bm->checkfile(filepath);
 //    emit d->bm->startCheckfile(filepath);
 //    return true;
-}
-
-bool BootMakerServicePrivate::checkCaller()
-{
-    if (disableCheck) {
-        return true;
-    }
-
-    Q_Q(BootMakerService);
-    if (!q->calledFromDBus()) {
-        return false;
-    }
-
-    qint64 callerPid = dbusCallerPid();
-    QString callerExe = getProcIdExe(callerPid);
-    QString dbmExe = QStandardPaths::findExecutable("deepin-boot-maker", {"/usr/bin"});
-
-    qDebug() << "callerPid is: " << callerPid << "callerExe is:" << callerExe;
-
-    if (callerExe != dbmExe) {
-        qDebug() << QString("caller not authorized") ;
-        return false;
-    }
-    qDebug() <<  QString("caller authorized");
-
-    return true;
 }
 
 /**

--- a/src/service/bootmakerservice_p.h
+++ b/src/service/bootmakerservice_p.h
@@ -17,7 +17,6 @@ public:
     {
     }
     ~BootMakerServicePrivate() {}
-    bool checkCaller();
     qint64 dbusCallerPid();
 
     bool disableCheck = false;

--- a/src/src.pro
+++ b/src/src.pro
@@ -10,7 +10,7 @@ linux {
 
 }
 SUBDIRS += app
-SUBDIRS += tests
+# SUBDIRS += tests
 mac* {
     TRANSLATIONS_NAME = deepin-boot-maker
     TRANSLATIONS += $$PWD/translations/$${TRANSLATIONS_NAME}.ts \


### PR DESCRIPTION
- Remove unused getProcIdByExeName function and related code
- Replace custom checkCaller method with polkit authorization checks
- Update Start, Stop, DeviceList, and Install methods to use checkAuthorization instead of checkCaller
- Remove getProcIdExe helper function
- Keep CheckFile method with commented authorization check for future use

Log: refactor(service): replace custom caller check with polkit authorization
Bug:  https://pms.uniontech.com/task-view-386841.html

Please do not send pull requests to the linuxdeepin/*
    
see https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers
    
Thanks!
