### PR TITLE
deps: migrate from p7zip-full to 7zip package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Vcs-Browser: https://salsa.debian.org/pkg-deepin-team/deepin-boot-maker
 
 Package: deepin-boot-maker
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, p7zip-full, mtools, udisks2,
+Depends: ${shlibs:Depends}, ${misc:Depends}, 7zip, mtools, udisks2,
  syslinux [linux-amd64 linux-i386],
  syslinux-common [linux-amd64 linux-i386], genisoimage,
  dde-qt6integration

--- a/rpm/deepin-boot-maker.spec
+++ b/rpm/deepin-boot-maker.spec
@@ -34,7 +34,7 @@ BuildRequires: libXext-devel
 Requires: syslinux
 Requires: syslinux-nonlinux
 %endif
-Requires: p7zip
+Requires: 7zip
 Requires: mtools
 Requires: udisks2
 Requires: genisoimage


### PR DESCRIPTION
Replace deprecated p7zip-full package with 7zip in both Debian and RPM packaging specifications. The code already uses the "7z" command-line interface which both packages provide, so no code changes are required.

TASK: https://pms.uniontech.com/task-view-388177.html

Please do not send pull requests to the linuxdeepin/*
    
see https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers
    
Thanks!

## Summary by Sourcery

Build:
- Replace p7zip with 7zip as a runtime dependency in the RPM spec.