### PR TITLE
chore: Update version to 6.0.14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-boot-maker (6.0.14) unstable; urgency=medium
+
+  * deps: migrate from p7zip-full to 7zip package
+  * chore(CI): add debian check workflow
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 09 Apr 2026 13:47:50 +0800
+
 deepin-boot-maker (6.0.13) unstable; urgency=medium
 
   * fix: bash command hardening


### PR DESCRIPTION
- update version to 6.0.14

log: update version to 6.0.14

Please do not send pull requests to the linuxdeepin/*
    
see https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers
    
Thanks!

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 6.0.14 release.