### PR TITLE
Revert "deps: migrate from p7zip-full to 7zip package"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Vcs-Browser: https://salsa.debian.org/pkg-deepin-team/deepin-boot-maker
 
 Package: deepin-boot-maker
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, 7zip, mtools, udisks2,
+Depends: ${shlibs:Depends}, ${misc:Depends}, p7zip-full, mtools, udisks2,
  syslinux [linux-amd64 linux-i386],
  syslinux-common [linux-amd64 linux-i386], genisoimage,
  dde-qt6integration

--- a/rpm/deepin-boot-maker.spec
+++ b/rpm/deepin-boot-maker.spec
@@ -34,7 +34,7 @@ BuildRequires: libXext-devel
 Requires: syslinux
 Requires: syslinux-nonlinux
 %endif
-Requires: 7zip
+Requires: p7zip
 Requires: mtools
 Requires: udisks2
 Requires: genisoimage


### PR DESCRIPTION
由于系统依赖还没有完善，启动盘制作工作的这笔提交先回滚。后续系统依赖处
理了再添加进去。

This reverts commit 4764b6713de8a5b223bbadbecd7e23988b40a0c6.

Please do not send pull requests to the linuxdeepin/*
    
see https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers
    
Thanks!

## Summary by Sourcery

Build:
- Switch the package dependency from 7zip back to p7zip in the RPM spec to align with existing system dependencies.