### PR TITLE
Revert "deps: migrate from p7zip-full to 7zip package"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Vcs-Browser: https://salsa.debian.org/pkg-deepin-team/deepin-boot-maker
 
 Package: deepin-boot-maker
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, 7zip, mtools, udisks2,
+Depends: ${shlibs:Depends}, ${misc:Depends}, p7zip-full, mtools, udisks2,
  syslinux [linux-amd64 linux-i386],
  syslinux-common [linux-amd64 linux-i386], genisoimage,
  dde-qt6integration

--- a/rpm/deepin-boot-maker.spec
+++ b/rpm/deepin-boot-maker.spec
@@ -34,7 +34,7 @@ BuildRequires: libXext-devel
 Requires: syslinux
 Requires: syslinux-nonlinux
 %endif
-Requires: 7zip
+Requires: p7zip
 Requires: mtools
 Requires: udisks2
 Requires: genisoimage


### PR DESCRIPTION
This reverts commit 4764b6713de8a5b223bbadbecd7e23988b40a0c6.

## Summary by Sourcery

Restore the runtime dependency on the legacy p7zip package instead of 7zip in the RPM packaging metadata.

Bug Fixes:
- Revert the previous migration to 7zip to ensure compatibility with environments that still rely on the p7zip package.

Build:
- Adjust RPM spec to depend on p7zip rather than 7zip.