### PR TITLE
fix(usbselect): set fixed height for warning hint label to prevent la…

### DIFF
--- a/src/app/view/usbselectview.cpp
+++ b/src/app/view/usbselectview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -129,6 +129,7 @@ UsbSelectView::UsbSelectView(DWidget *parent) : DWidget(parent)
     font.setWeight(QFont::Normal);
     m_warningHint->setFont(font);
     m_warningHint->setAlignment(Qt::AlignCenter);
+    m_warningHint->setFixedHeight(50);
     QHBoxLayout* pWarningLayout = new QHBoxLayout;
     pWarningLayout->setContentsMargins(30, 0, 30, 0);
     pWarningLayout->addWidget(m_warningHint);


### PR DESCRIPTION
- Set fixed height 50px for m_warningHint label in UsbSelectView to avoid layout jumping when warning text changes

修复(usbselect): 为警告提示标签设置固定高度以防止布局跳动

- 在 UsbSelectView 中为 m_warningHint 警告提示标签设置固定高度 50px，避免警告文本变化时布局跳动

Log: 为 USB 选择界面的警告提示标签设置固定高度，防止文本内容变化引起的布局跳动
Bug: https://pms.uniontech.com/bug-view-241751.html
