### PR TITLE
fix(device): correct disk size unit conversion from KB to MB in Comma…

### DIFF
--- a/src/libdbm/util/utils.cpp
+++ b/src/libdbm/util/utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -324,7 +324,7 @@ QMap<QString, DeviceInfo> CommandLsblkParse()
             deviceCount++;
             info.path = reg.cap(1);
             info.label = reg.cap(2);
-            info.total = reg.cap(3).toLongLong() * 1024 / 1024; // MB
+            info.total = reg.cap(3).toLongLong() / 1024 / 1024; // MB
             info.uuid = reg.cap(4);
             info.fstype = reg.cap(5);
             type = reg.cap(6);


### PR DESCRIPTION
…ndLsblkParse()

- Fix disk size calculation by dividing by 1024 twice (KB to MB) instead of multiplying by 1024 then dividing by 1024, which produced incorrect values

修复(device): 修正 CommandLsblkParse 中磁盘容量 KB 到 MB 的单位转换

- 修正磁盘容量计算，将 KB 到 MB 的转换从先乘 1024 再除 1024 修正为连续除以两次 1024，避免计算结果错误

Log: 修正 lsblk 解析中磁盘容量单位转换逻辑，将错误的乘除组合修正为连续除法以得到正确的 MB 值
Bug: https://pms.uniontech.com/bug-view-349331.html
