### PR TITLE
fix(installer): add partition device existence check to handle physic…

### DIFF
--- a/src/libdbm/installer/qtbaseinstaller.cpp
+++ b/src/libdbm/installer/qtbaseinstaller.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -171,6 +171,14 @@ void QtBaseInstaller::checkError()
     }
 
     qInfo() << "begin check error";
+
+    // Check if the partition device still exists (handles physical USB removal)
+    if (!QFile::exists(m_strPartionName)) {
+        qCritical() << "Error::get(Error::USBMountFailed) device removed:" << m_strPartionName;
+        emit progressfinished(m_progressStatus, BMHandler::ErrorType::USBMountFailed);
+        return;
+    }
+
     QString strDisk = XSys::DiskUtil::GetPartitionDisk(m_strPartionName);
 
     if (strDisk.isEmpty()) {


### PR DESCRIPTION
…al USB removal

- Add QFile::exists() check for partition device in QtBaseInstaller::checkError() before disk lookup to handle physical USB removal gracefully

修复(installer): 增加分区设备存在性检查以处理 USB 物理拔出场景

- 在 QtBaseInstaller::checkError() 中调用磁盘查找前增加 QFile::exists() 检查分区设备是否存在，优雅处理 USB 被物理拔出的情况

Log: 在安装器错误检查流程中增加分区设备存在性检查，防止 USB 被物理拔出后继续执行导致异常
Bug: https://pms.uniontech.com/bug-view-354921.html
