### PR TITLE
chore(license): add missing exportPot.bat to REUSE dep5 file declaration

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -49,7 +49,7 @@ Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 
 # eliminate files in src/tools
-Files: src/tools/exportPot src/tools/importPo src/tools/importPo.bat
+Files: src/tools/exportPot src/tools/exportPot.bat src/tools/importPo src/tools/importPo.bat
 Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 


### PR DESCRIPTION
- Add src/tools/exportPot.bat to the dep5 file list to fix REUSE compliance check failure with reuse >= 6.0

构建(license): 补充 dep5 中遗漏的 exportPot.bat 文件声明

- 在 dep5 文件列表中补充 src/tools/exportPot.bat，修复 reuse 6.0+ 版本合规检查失败的问题

Log: 补充 dep5 声明文件中遗漏的 exportPot.bat，修复新版本 reuse 工具的开源合规检查失败
