### PR TITLE
refactor: remove unnecessary Polkit auth checks & fix fdisk input

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-boot-maker (6.0.16) unstable; urgency=medium
+
+  * fix(disk): use temp file instead of shell pipe for fdisk input
+  * refactor(auth): remove unnecessary Polkit authorization checks
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 14 May 2026 19:33:59 +0800
+
 deepin-boot-maker (6.0.15) unstable; urgency=medium
 
   * Revert "deps: migrate from p7zip-full to 7zip package"

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -14,25 +14,10 @@
 #include <DApplication>
 #include <DWidgetUtil>
 #include <DGuiApplicationHelper>
-#include <QDBusConnection>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <DApplicationSettings>
 #endif
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#if defined (Q_OS_LINUX)
-#include <polkit-qt5-1/PolkitQt1/Authority>
-#include <polkit-qt5-1/PolkitQt1/Subject>
-#endif
-#else
-#if defined (Q_OS_LINUX)
-#include <polkit-qt6-1/PolkitQt1/Authority>
-#include <polkit-qt6-1/PolkitQt1/Subject>
-#endif
-#endif
-
-const QString s_PolkitActionCreate = "com.deepin.bootmaker.create";
 
 
 DCORE_USE_NAMESPACE
@@ -68,27 +53,6 @@ static bool switchToRoot(QApplication &app)
 
 #endif
 
-// 在前端中预先进行身份验证, 便于流程控制
-bool checkAuthorization()
-{
-#if defined (Q_OS_LINUX)
-    QString busName = QDBusConnection::systemBus().baseService();
-    auto authority = PolkitQt1::Authority::instance();
-    if (!authority) {
-        qWarning() << "Failed to get Polkit authority instance";
-        return false;
-    }
-    PolkitQt1::Authority::Result ret = authority->checkAuthorizationSync(
-        s_PolkitActionCreate,
-        PolkitQt1::SystemBusNameSubject(busName),
-        PolkitQt1::Authority::AllowUserInteraction);
-
-    return PolkitQt1::Authority::Yes == ret;
-#else
-    return true;
-#endif
-}
-
 int main(int argc, char **argv)
 {
     qInfo() << "Starting Boot Maker application";
@@ -113,11 +77,6 @@ int main(int argc, char **argv)
     app.setApplicationVersion(DApplication::buildVersion("20191031"));
 //    app.setApplicationVersion(DApplication::buildVersion(VERSION));
 //    app.setTheme("light");
-
-    if (!checkAuthorization()) {
-        qInfo() << "Authorization failed, exiting";
-        return 1;
-    }
 
 #ifdef Q_OS_MAC
     qDebug() << "Checking root privileges on macOS";

--- a/src/service/bootmakerservice.cpp
+++ b/src/service/bootmakerservice.cpp
@@ -128,26 +128,14 @@ void BootMakerService::Reboot()
 
 void BootMakerService::Start()
 {
-    Q_D(BootMakerService);
-    qInfo() << "Start requested";
-    if (!d->checkAuthorization(s_PolkitActionCreate)) {
-        qWarning() << "Start request denied - Authorization failed";
-        return;
-    }
-
+    // 启动服务, 不会修改系统, 不需要鉴权
     qDebug() << "Starting Boot Maker";
     emit s_StartBootMarker();
 }
 
 void BootMakerService::Stop()
 {
-    Q_D(BootMakerService);
-    qInfo() << "Stop requested";
-    if (!d->checkAuthorization(s_PolkitActionCreate)) {
-        qWarning() << "Stop request denied - Authorization failed";
-        return;
-    }
-
+    // 停止服务, 不会修改系统, 不需要鉴权
     qDebug() << "Stopping Boot Maker Service";
     qApp->exit(0);
 }
@@ -158,12 +146,9 @@ void BootMakerService::Stop()
 //! return json of devicelist
 QString BootMakerService::DeviceList()
 {
+    // BootMaker::deviceList() 是只读操作, 不需要鉴权
     Q_D(BootMakerService);
     qDebug() << "Device list requested";
-    if (!d->checkAuthorization(s_PolkitActionCreate)) {
-        qWarning() << "Device list request denied - Authorization failed";
-        return "";
-    }
     return deviceListToJson(d->bm->deviceList());
 }
 
@@ -184,6 +169,7 @@ bool BootMakerService::Install(const QString &image, const QString &device, cons
 
 bool BootMakerService::CheckFile(const QString &filepath)
 {
+    // BootMaker::checkfile() 是只读操作, 不需要鉴权
     Q_D(BootMakerService);
     qDebug() << "File check requested:" << filepath;
     return d->bm->checkfile(filepath);

--- a/src/vendor/src/libxsys/DiskUtil/DiskUtil.cpp
+++ b/src/vendor/src/libxsys/DiskUtil/DiskUtil.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -642,8 +642,18 @@ bool CreatePartition(const QString& diskDev)
 
     qDebug() << "Creating partition for disk" << diskDev;
 
-    QString cmd = QString("echo -e 'o\\nn\\np\\n1\\n\\n\\nw' | fdisk ") + diskDev;
-    XSys::Result result = XSys::SynExec("bash", "-c \"" + cmd + "\"");
+    QTemporaryFile tmpFile;
+    if (!tmpFile.open()) {
+        qWarning() << "Failed to create fdisk input file:" << tmpFile.errorString();
+        return false;
+    }
+    QTextStream out(&tmpFile);
+    out << "o\nn\np\n1\n\n\nw\n";
+    tmpFile.close();
+
+    XSys::Result result = XSys::SynExec(XSys::FS::SearchBin("fdisk"),
+                                        diskDev,
+                                        tmpFile.fileName());
 
     if (!result.isSuccess()) {
         qWarning() << "Failed to create partition table with fdisk for" << diskDev;


### PR DESCRIPTION
## Summary
- **refactor(auth)**: 移除前端预授权和非破坏性操作（Start/Stop/DeviceList/CheckFile）的后端 Polkit 授权检查，仅保留 Install 操作的授权，遵循最小权限原则
- **fix(disk)**: 使用 QTemporaryFile 替代 echo 管道传递 fdisk 命令，避免 shell 解析和潜在的转义问题
- **chore**: 升级版本号至 6.0.16

## Test plan
- [x] 验证启动/停止服务无需授权即可正常使用
- [x] 验证设备列表和文件检查无需授权即可正常使用
- [x] 验证 Install 操作仍然需要 Polkit 授权
- [x] 验证 fdisk 分区创建在含特殊字符的磁盘路径下正常工作

PMS: TASK-389581

## Summary by Sourcery

Relax authorization requirements for non-destructive bootmaker operations and harden disk partition command handling.

Bug Fixes:
- Use a temporary file instead of shell piping to pass scripted input to fdisk, avoiding shell parsing and escaping issues with special characters in device paths.

Enhancements:
- Remove global startup Polkit pre-authorization and drop Polkit checks from non-destructive service methods (Start, Stop, DeviceList, CheckFile) while retaining authorization for installation operations to align with least-privilege principles.

Build:
- Bump package version to 6.0.16 in Debian packaging metadata.