### PR TITLE
fix(disk): propagate SetPartionLabel errors to installer layer

### DIFF
--- a/src/libdbm/installer/qtX86Installer.cpp
+++ b/src/libdbm/installer/qtX86Installer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -47,7 +47,10 @@ bool QtX86Installer::installBootload()
     }
 
     qDebug() << "Setting partition label for image:" << m_strImage;
-    XSys::DiskUtil::SetPartionLabel(m_strPartionName, m_strImage);
+    if (!XSys::DiskUtil::SetPartionLabel(m_strPartionName, m_strImage)) {
+        qCritical() << "Failed to set partition label";
+        return false;
+    }
     
     qInfo() << "Bootloader installation completed successfully";
     return true;

--- a/src/libdbm/installer/qtmipsinstaller.cpp
+++ b/src/libdbm/installer/qtmipsinstaller.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -31,7 +31,10 @@ bool QtMipsInstaller::installBootload()
     }
 
     qDebug() << "Setting partition label for image:" << m_strImage;
-    XSys::DiskUtil::SetPartionLabel(m_strPartionName, m_strImage);
+    if (!XSys::DiskUtil::SetPartionLabel(m_strPartionName, m_strImage)) {
+        qCritical() << "Failed to set partition label";
+        return false;
+    }
     
     qInfo() << "Bootloader installation completed successfully";
     return true;

--- a/src/vendor/src/libxsys/Cmd/Cmd.cpp
+++ b/src/vendor/src/libxsys/Cmd/Cmd.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -63,6 +63,10 @@ Result SynExec(const QString &exec, const QString &param, const QString &execPip
     Result ret = runApp(exec, param, execPipeIn);
     qInfo() << "call:" << exec + " " + param << "with:" << execPipeIn ;
     qInfo() << "resut:" << ret.isSuccess();
+    if (!ret.isSuccess()) {
+        qInfo() << "stdout:" << ret.result();
+        qInfo() << "stderr:" << ret.errmsg();
+    }
     return ret;
 }
 

--- a/src/vendor/src/libxsys/DiskUtil/DiskUtil.cpp
+++ b/src/vendor/src/libxsys/DiskUtil/DiskUtil.cpp
@@ -745,33 +745,38 @@ bool SetActivePartion(const QString& strDisk, const QString& strPartion)
     return ret.isSuccess();
 }
 
-void SetPartionLabel(const QString& strPartion, const QString& strImage)
+bool SetPartionLabel(const QString& strPartion, const QString& strImage)
 {
-    /*QProcess cannot handle Chinese paths*/
-    XSys::SynExec(XSys::FS::SearchBin("fsck"), QString("-y %1").arg(strPartion));
-    QStringList args;
-    args << "-i" << strImage << "-d";
-    XSys::Result ret3 = XSys::SynExec("isoinfo", args);
-
-    if (!ret3.isSuccess()) {
-        qWarning() << "call isoinfo failed" << ret3.result();
-        return;
+    if (!XSys::SynExec(XSys::FS::SearchBin("fsck"), QStringList{"-y", strPartion}).isSuccess()) {
+        qWarning() << "fsck failed on" << strPartion << ", continuing anyway";
     }
 
-    QStringList volume = ret3.result().split("\n").filter("Volume id");
-    QString tem = volume.takeAt(0);
-    QStringList strValues = tem.split(":");
-    QString strName = QString("UNKNOWN");
-    QString strTemp;
-
-    if (2 <= strValues.size()) {
-        strTemp = strValues.at(1);
-        strTemp = strTemp.trimmed();
+    XSys::Result isoResult = XSys::SynExec("isoinfo", QStringList{"-i", strImage, "-d"});
+    if (!isoResult.isSuccess()) {
+        qWarning() << "call isoinfo failed:" << isoResult.result();
+        return false;
     }
 
-    //标签名最长长度为十一位
-    strName = strTemp.isEmpty()?strName:(strTemp.length() > 11)?strTemp.left(11):strTemp;
-    XSys::SynExec(XSys::FS::SearchBin("fatlabel"), QString(" %1 \"%2\"").arg(strPartion).arg(strName));
+    // Volume id 格式: "Volume id: DEEPIN" 或 "Volume id: UOS"
+    QString volumeId;
+    for (const QString &line : isoResult.result().split("\n")) {
+        if (line.startsWith("Volume id:")) {
+            volumeId = line.split(":").last().trimmed();
+            break;
+        }
+    }
+
+    if (volumeId.isEmpty()) {
+        qWarning() << "No volume id found in isoinfo output";
+        return false;
+    }
+
+    // FAT32 卷标最长 11 字符
+    QString label = volumeId.left(11);
+    if (volumeId.length() > 11) {
+        qWarning() << "Volume id truncated:" << volumeId << "->" << label;
+    }
+    return XSys::SynExec(XSys::FS::SearchBin("fatlabel"), QStringList{strPartion, label}).isSuccess();
 }
 
 QString getPartitionUUID(const QString& strPartition)

--- a/src/vendor/src/libxsys/DiskUtil/DiskUtil.h
+++ b/src/vendor/src/libxsys/DiskUtil/DiskUtil.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -34,7 +34,7 @@ bool FormatPartion(const QString& targetDev);
 bool CreatePartition(const QString& diskDev);
 QStringList GetPartionOfDisk(const QString& strDisk);
 bool SetActivePartion(const QString& strDisk, const QString& strPartion);
-void SetPartionLabel(const QString& strPartion, const QString& strImage);
+bool SetPartionLabel(const QString& strPartion, const QString& strImage);
 QString getPartitionUUID(const QString& strPartition);
 }
 


### PR DESCRIPTION
## Summary

- Change `SetPartionLabel` return type from `void` to `bool` to propagate errors
- Handle `fsck` failure gracefully (warn but continue)
- Improve Volume id parsing logic for robustness
- Callers (`QtX86Installer`, `QtMipsInstaller`) now check return value and abort on failure

## Test plan

- [ ] Verify bootable USB creation still works with valid ISO images
- [ ] Verify error is reported when isoinfo fails or returns no volume id
- [ ] Verify volume id truncation works for labels longer than 11 characters

## Summary by Sourcery

Bug Fixes:
- Ensure Qt x86 and MIPS installers detect and fail installation when setting the partition label fails instead of ignoring errors.