### PR TITLE
chore: Bump version to 6.0.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-boot-maker (6.0.17) unstable; urgency=medium
+
+  * fix(disk): propagate SetPartionLabel errors to installer layer
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 21 May 2026 21:58:37 +0800
+
 deepin-boot-maker (6.0.16) unstable; urgency=medium
 
   * fix(disk): use temp file instead of shell pipe for fdisk input


### PR DESCRIPTION
## Summary
- Update debian changelog for version 6.0.17 release
- Includes fix: propagate SetPartitionLabel errors to installer layer

## Test plan
- [x] Verify changelog format is correct
- [x] Verify version bump is consistent with code changes

## Summary by Sourcery

Build:
- Bump Debian package changelog to version 6.0.17, including notes for the SetPartitionLabel error propagation fix.