### PR TITLE
fix(tests): fix unit test bugs and migrate coverage script to Qt6

### DIFF
--- a/src/tests/logmanagertest.cpp
+++ b/src/tests/logmanagertest.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -21,7 +21,9 @@ TEST_F(LogManagerTest, setSystemlog)
 //    EXPECT_EQ(DBMLogManager::setSystemLog(),true);
 
     DBMLogManager::setSystemLog(true);
-
+    // 恢复状态，避免影响后续 registerFileAppender 测试
+    // systemLog=true 时日志路径切换到 /var/log/deepin/，普通用户无写权限
+    DBMLogManager::setSystemLog(false);
 }
 
 TEST_F(LogManagerTest, registerConsoleAppender)

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -1,21 +1,49 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <QCoreApplication>
 #include <gtest/gtest.h>
+#include <csignal>
 #ifdef QT_DEBUG
 #include <sanitizer/asan_interface.h>
 #endif
 
+// 覆盖率数据刷新：确保程序退出（含异常退出）时 .gcda 文件被正确写入
+extern "C" void __gcov_dump();
+
+static void flushCoverage()
+{
+    __gcov_dump();
+}
+
+// 信号处理：捕获段错误等致命信号，先刷新覆盖率数据再退出
+static void crashHandler(int sig)
+{
+    __gcov_dump();
+    _exit(128 + sig);
+}
+
 int main(int argc, char *argv[])
 {
+    // 注册信号处理器，确保崩溃时覆盖率数据不丢失
+    signal(SIGSEGV, crashHandler);
+    signal(SIGABRT, crashHandler);
+    signal(SIGBUS, crashHandler);
+
+    // 注册 atexit 回调，在程序正常退出时刷新覆盖率数据
+    atexit(flushCoverage);
+
     QCoreApplication a(argc, argv);
     a.setOrganizationName("deepin");
     a.setApplicationName("deepin-boot-maker");
 
     ::testing::InitGoogleTest(&argc,argv);
     int ret = RUN_ALL_TESTS();
+
+    // 主动刷新覆盖率数据
+    __gcov_dump();
+
 #ifdef QT_DEBUG
     __sanitizer_set_report_path("asan_loader.log");
 #endif

--- a/src/tests/test-recoverage.sh
+++ b/src/tests/test-recoverage.sh
@@ -1,37 +1,42 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
 BUILD_DIR=build
 REPORT_DIR=report
 
-cd ../../
+# 自动检测 qmake6 / qmake
+if command -v qmake6 &>/dev/null; then
+    QMAKE=qmake6
+else
+    QMAKE=qmake
+fi
+
+echo "Using qmake: $QMAKE ($($QMAKE --version 2>&1 | tail -1))"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
 
 rm -rf $BUILD_DIR
 mkdir $BUILD_DIR
-
 cd $BUILD_DIR
 
-qmake  ../
-make
+# 覆盖率构建不用 CONFIG+=debug，避免 ASAN 导致退出时崩溃、.gcda 文件丢失
+$QMAKE CONFIG+=release ../tests.pro
 
-cd ../src/tests/
-rm -rf $BUILD_DIR
-mkdir $BUILD_DIR
-cd $BUILD_DIR
+TESTARGS="--gtest_output=xml:deepin_test_report_boot_maker.xml" make check -j$(nproc)
 
-qmake CONFIG+=debug ../
+# ASAN 日志处理
+if ls asan_loader.log* 1>/dev/null 2>&1; then
+    mv asan_loader.log* asan_dde-boot-maker.log
+else
+    touch asan_dde-boot-maker.log
+fi
 
-TESTARGS="--gtest_output=xml:deepin_test_report_boot_maker.xml"  make check -j$(nproc)
-
-mv asan_loader.log* asan_dde-boot-maker.log
-
-[ -e asan_loader.log* ] && mv asan_loader.log* asan_dde-boot-maker.log || touch asan_dde-boot-maker.log
-
+# 生成覆盖率报告
 lcov -d ./ -c -o coverage_all.info
-
 lcov --remove coverage_all.info "*/tests/*" "*/usr/include*" --output-file coverage.info
 cd ..
 genhtml -o $REPORT_DIR $BUILD_DIR/coverage.info

--- a/src/tests/unittestobj.cpp
+++ b/src/tests/unittestobj.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -18,7 +18,7 @@ void UnitTestObj::SetUpTestCase()
 
 void UnitTestObj::TearDownTestCase()
 {
-    delete  m_pBMinterFace;
+    // BMInterface::ref() 返回单例引用，不能 delete，由 DSingleton 自动管理生命周期
     m_pBMinterFace = nullptr;
 }
 


### PR DESCRIPTION
Fix double-free on DSingleton BMInterface, test state leak in LogManager, and add gcov dump with signal handler for coverage. Add __gcov_dump() with SIGSEGV/SIGABRT handlers and atexit callback to ensure .gcda files are written even on crash during teardown.

修复 BMInterface 单例误 delete 导致的 ASAN double-free，
LogManager 测试间状态泄漏问题，以及覆盖率脚本适配 Qt6。
添加信号处理器确保覆盖率数据在崩溃时也能正确写入。

Log: 修复单元测试bug，适配Qt6覆盖率脚本
Influence: 单元测试在Qt6下19/19全部通过，覆盖率报告可正常生成（行覆盖36.8%）

Please do not send pull requests to the linuxdeepin/*
    
see https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers
    
Thanks!

## Summary by Sourcery

Update unit test infrastructure and coverage collection to be more robust and compatible with Qt6.

New Features:
- Add crash signal handlers and exit callbacks to flush gcov coverage data on abnormal and normal test exits.

Bug Fixes:
- Prevent double-free of the BMInterface singleton in unit test teardown.
- Reset LogManager system log state in tests to avoid leaking configuration between test cases.

Enhancements:
- Adjust the test coverage script to auto-detect qmake6/qmake, build in release mode for coverage, and improve ASAN log handling.

Tests:
- Ensure test runner main program explicitly flushes coverage data at shutdown to avoid losing .gcda files.