### PR TITLE
fix(auth): add polkit authorization check for Start

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -14,10 +14,25 @@
 #include <DApplication>
 #include <DWidgetUtil>
 #include <DGuiApplicationHelper>
+#include <QDBusConnection>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <DApplicationSettings>
 #endif
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if defined (Q_OS_LINUX)
+#include <polkit-qt5-1/PolkitQt1/Authority>
+#include <polkit-qt5-1/PolkitQt1/Subject>
+#endif
+#else
+#if defined (Q_OS_LINUX)
+#include <polkit-qt6-1/PolkitQt1/Authority>
+#include <polkit-qt6-1/PolkitQt1/Subject>
+#endif
+#endif
+
+const QString s_PolkitActionCreate = "com.deepin.bootmaker.create";
 
 
 DCORE_USE_NAMESPACE
@@ -53,6 +68,27 @@ static bool switchToRoot(QApplication &app)
 
 #endif
 
+// 在前端中预先进行身份验证, 便于流程控制
+static bool checkAuthorization()
+{
+#if defined (Q_OS_LINUX)
+    QString busName = QDBusConnection::systemBus().baseService();
+    auto authority = PolkitQt1::Authority::instance();
+    if (!authority) {
+        qWarning() << "Failed to get Polkit authority instance";
+        return false;
+    }
+    PolkitQt1::Authority::Result ret = authority->checkAuthorizationSync(
+        s_PolkitActionCreate,
+        PolkitQt1::SystemBusNameSubject(busName),
+        PolkitQt1::Authority::AllowUserInteraction);
+
+    return PolkitQt1::Authority::Yes == ret;
+#else
+    return true;
+#endif
+}
+
 int main(int argc, char **argv)
 {
     qInfo() << "Starting Boot Maker application";
@@ -77,6 +113,11 @@ int main(int argc, char **argv)
     app.setApplicationVersion(DApplication::buildVersion("20191031"));
 //    app.setApplicationVersion(DApplication::buildVersion(VERSION));
 //    app.setTheme("light");
+
+    if (!checkAuthorization()) {
+        qInfo() << "Authorization failed, exiting";
+        exit(0);
+    }
 
 #ifdef Q_OS_MAC
     qDebug() << "Checking root privileges on macOS";

--- a/src/service/bootmakerservice.cpp
+++ b/src/service/bootmakerservice.cpp
@@ -128,7 +128,13 @@ void BootMakerService::Reboot()
 
 void BootMakerService::Start()
 {
-    // 启动服务, 不会修改系统, 不需要鉴权
+    Q_D(BootMakerService);
+    qInfo() << "Start requested";
+    if (!d->checkAuthorization(s_PolkitActionCreate)) {
+        qWarning() << "Start request denied - Authorization failed";
+        return;
+    }
+
     qDebug() << "Starting Boot Maker";
     emit s_StartBootMarker();
 }


### PR DESCRIPTION
## Summary

Add Polkit authentication to the `Start` interface in the service, and perform Polkit authentication in advance when the application starts.

在服务中为 `Start` 接口添加 Polkit 身份验证，并在应用启动时预先进行 Polkit 身份验证。

## Changes

- Add Polkit authorization check for the Start D-Bus interface
- Perform pre-authentication at application startup; exit immediately if authentication fails