### PR TITLE
chore: Bump version to 6.0.18

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-boot-maker (6.0.18) unstable; urgency=medium
+
+  * fix(tests): fix unit test bugs and migrate coverage script to Qt6
+  * fix(auth): add polkit authorization check for Start
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 11 Jun 2026 15:24:50 +0800
+
 deepin-boot-maker (6.0.17) unstable; urgency=medium
 
   * fix(disk): propagate SetPartionLabel errors to installer layer


### PR DESCRIPTION
Release version 6.0.18

## Changes
- fix(tests): fix unit test bugs and migrate coverage script to Qt6
- fix(auth): add polkit authorization check for Start

## Summary by Sourcery

Bump Debian package metadata for the 6.0.18 release and update the changelog accordingly.

Bug Fixes:
- Document test fixes and Qt6 coverage script migration for this release.
- Document addition of a polkit authorization check for Start in this release.