### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/app/platform/linux/deepin-boot-maker.desktop
+++ b/src/app/platform/linux/deepin-boot-maker.desktop
@@ -175,7 +175,7 @@ Name[ug]=چوڭقۇر قوزغىتىش تاختىسى ياساش قورالى
 Name[uk]=Засіб створення дисків з Deepin
 Name[vi]=Deepin Boot Maker
 Name[lo]=Deepin ເຄື່ອງສ້າງບູດ
-Name[zh_CN]=深度启动盘制作工具
-Name[zh_HK]=Deepin 開機碟製作
-Name[zh_TW]=Deepin 開機碟製作器
+Name[zh_CN]=启动盘制作工具
+Name[zh_HK]=開機碟製作
+Name[zh_TW]=開機碟製作器
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese (zh_CN/zh_HK/zh_TW) desktop file translations by removing unnecessary "深度"/"deepin"/"Deepin" prefixes from Name and Comment fields.