### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/src/app/platform/linux/deepin-boot-maker.desktop
+++ b/src/app/platform/linux/deepin-boot-maker.desktop
@@ -10,6 +10,7 @@ Terminal=false
 Type=Application
 Version=1.0
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Build:
- Update the Deepin Boot Maker .desktop file to include the X-Deepin-Singleton flag for singleton app handling.