### PR TITLE
fix(app): remove deprecated macOS root privilege escalation code with command injection risk

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,10 +1,9 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <QDebug>
 #include <QIcon>
-#include <QProcess>
 
 #include "bmwindow.h"
 #include <bminterface.h>
@@ -18,36 +17,6 @@
 
 DCORE_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
-
-#ifdef Q_OS_MAC
-static bool switchToRoot(QApplication &app)
-{
-    QStringList allappargs = app.arguments();
-    QProcess whoamip;
-    whoamip.start("whoami");
-    whoamip.waitForFinished();
-
-    if (QString(whoamip.readAll()).remove("\r").remove("\n") != "root") {
-        QString argsconc = "";
-        QString argsconcSingleQuote = "";
-
-        for (int i = 1; i < allappargs.size(); ++i) {
-            argsconc += QString("\"%1\" ").arg(allappargs.at(i));
-            argsconcSingleQuote += QString("'%1' ").arg(allappargs.at(i));
-        }
-
-        argsconc += "\"rootcheck=no\"";
-        argsconcSingleQuote += "'rootcheck=no'";
-
-        QProcess::startDetached("osascript", QStringList() << "-e" << QString("do shell script \"'%1' %2\" with administrator privileges").arg(app.applicationFilePath()).arg(argsconcSingleQuote));
-        return true;
-
-    }
-
-    return false;
-}
-
-#endif
 
 int main(int argc, char **argv)
 {
@@ -73,22 +42,15 @@ int main(int argc, char **argv)
 //    app.setApplicationVersion(DApplication::buildVersion(VERSION));
 //    app.setTheme("light");
 
-#ifdef Q_OS_MAC
-    if (switchToRoot(app)) {
-        exit(0);
-    }
-#endif
     const QString m_format = "%{time}{yyyyMMdd.HH:mm:ss.zzz}[%{type:1}][%{function:-40} %{line:-4} %{threadid:-8} ] %{message}\n";
     DLogManager::setLogFormat(m_format);
     DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();
 
-#ifndef Q_OS_MAC
     qputenv("DTK_USE_SEMAPHORE_SINGLEINSTANCE", "1");
     if (!DGuiApplicationHelper::instance()->setSingleInstance(app.applicationName(), DGuiApplicationHelper::UserScope)) {
         exit(0);
     }
-#endif
 
 #ifdef Q_OS_WIN
     Utils::loadFonts();


### PR DESCRIPTION
## Summary

- Remove the unused `switchToRoot()` function guarded by `Q_OS_MAC`, which concatenated external argv into an osascript "do shell script ... with administrator privileges" string without escaping, posing a command injection risk (CWE-78)
- Remove the `switchToRoot()` call site in `main()` and the unused `QProcess` include
- Unwrap the single-instance check from `#ifndef Q_OS_MAC` since the code now only targets Linux, keeping behavior unchanged
- Update SPDX copyright end year to 2026

## 修复内容

- 移除 `Q_OS_MAC` 宏保护的 `switchToRoot()` 函数，该函数将外部启动参数未转义地拼接进 osascript "do shell script ... with administrator privileges" 字符串，存在命令注入风险（CWE-78，安全扫描问题项 src/app/main.cpp:42）
- 移除 `main()` 中的调用点及不再使用的 `QProcess` 头文件
- 单实例检查去除 `#ifndef Q_OS_MAC` 宏包裹，代码现仅面向 Linux，行为保持不变
- SPDX 版权结束年份更新为 2026

## Impact

macOS 平台支持已于 2022 年随 commit 2ce7bb6 官方移除，此为残留死代码，删除后消除 AI 安全扫描报告的 High 级命令注入告警（CWE-78），Linux 构建行为不变，已编译验证。

Log: macOS 平台支持已于 2022 年随 commit 2ce7bb6 官方移除，此为残留死代码，删除后消除 AI 安全扫描报告的 High 级命令注入告警（CWE-78），Linux 构建行为不变，已编译验证
Bug: https://pms.uniontech.com/bug-view-375711.html

## Summary by Sourcery

Remove obsolete macOS support remnants and retain Linux single-instance behavior while eliminating the associated command-injection risk.

Bug Fixes:
- Remove deprecated macOS privilege-escalation code that could expose command-injection risk through unsanitized launch arguments.

Enhancements:
- Make single-instance enforcement unconditional for the supported platform targets and remove obsolete macOS-specific code paths.

Chores:
- Update the SPDX copyright end year to 2026.